### PR TITLE
fix: fix the bug which return ']' single string at empty time series

### DIFF
--- a/graphene-reader/src/main/java/net/iponweb/disthene/reader/format/ResponseFormatter.java
+++ b/graphene-reader/src/main/java/net/iponweb/disthene/reader/format/ResponseFormatter.java
@@ -204,10 +204,16 @@ public class ResponseFormatter {
     private static void appendResults(StringBuilder sb, List<TimeSeries> timeSeriesList) {
         sb.append("[");
         for (TimeSeries ts : timeSeriesList) {
+            if (isSecondTime(sb)) {
+                sb.append(",");
+            }
             appendTimeSeries(sb, ts);
         }
-        sb.deleteCharAt(sb.length() - 1);
         sb.append("]");
+    }
+
+    private static boolean isSecondTime(StringBuilder sb) {
+        return 2 <= sb.length();
     }
 
     private static void appendTimeSeries(StringBuilder sb, TimeSeries ts) {
@@ -219,6 +225,6 @@ public class ResponseFormatter {
             }
             sb.deleteCharAt(sb.length() - 1);
         }
-        sb.append("]},");
+        sb.append("]}");
     }
 }

--- a/graphene-reader/src/test/kotlin/net/iponweb/disthene/reader/format/ResponseFormatterTest.java
+++ b/graphene-reader/src/test/kotlin/net/iponweb/disthene/reader/format/ResponseFormatterTest.java
@@ -1,0 +1,32 @@
+package net.iponweb.disthene.reader.format;
+
+import com.graphene.reader.handler.RenderParameter;
+import io.netty.handler.codec.http.FullHttpResponse;
+import net.iponweb.disthene.reader.exceptions.LogarithmicScaleNotAllowed;
+import org.assertj.core.util.Lists;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ResponseFormatterTest {
+
+  @Test
+  void shouldReturnEmptyArrayIfNotExistsTimeSeriesData() throws LogarithmicScaleNotAllowed {
+    // when
+    FullHttpResponse response =
+        ResponseFormatter.formatResponse(Collections.emptyList(), defaultRenderParameter());
+
+    // then
+    assertThat("[]", is(new String(response.content().array(), StandardCharsets.UTF_8)));
+  }
+
+  @NotNull
+  private RenderParameter defaultRenderParameter() {
+    return new RenderParameter("NONE", Lists.newArrayList(), null, null, null, null, 480);
+  }
+}


### PR DESCRIPTION
*Background*
If time-series data is empty, Graphene returns ']' single string. 
This pull request resolves that issue.