### PR TITLE
Performance optimization on Controller.

### DIFF
--- a/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/GraphiteController.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/GraphiteController.kt
@@ -8,6 +8,7 @@ import com.graphene.common.HierarchyMetricPaths
 import com.graphene.reader.service.index.ElasticsearchIndexService
 import net.iponweb.disthene.reader.utils.MetricRule
 import org.apache.log4j.Logger
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.nio.charset.StandardCharsets
 
@@ -30,9 +31,8 @@ class GraphiteController(
   @PostMapping("/render")
   fun postRender(
     @ModelAttribute("renderRequest") renderRequest: RenderRequest
-  ): String {
-    val response = renderHandler.handle(RenderParameters.from(renderRequest))
-    return String(response.content().array(), StandardCharsets.UTF_8)
+  ): ResponseEntity<*> {
+    return renderHandler.handle(RenderParameters.from(renderRequest))
   }
 
   @RequestMapping("/metrics/find", "/find", method = [RequestMethod.POST, RequestMethod.GET])


### PR DESCRIPTION
Avoid to use Netty's FullHttpResponse.
Currently the responses are handled by Spring's RestController.
Therefore, we don't have to use Netty's FullHttpResponse.
In ResponseFormatter class, every response is created in FullHttpResponse with header 'Content-Length' whose values is set by length of a Byte Array generated by Unpooled.wrappedBuffer.
The Controller just uses the content set in FullHttpResponse and change it to String AGAIN to make response body to be handled by Spring's RestController, which are all unnecessary.
The optimization changes implementation to use ResponseEntity provided by Spring, and avoid to call getBytes when setting 'Content-Length' by using Guava's Utf8 class-implemented method.
This will greatly help graphene-reader to handle response quickly without making any chance of GC that is happening now.