### PR TITLE
bugfix: Prevent calling clearScroll if there's no scrollId.

### DIFF
--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/ElasticsearchKeySearchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/ElasticsearchKeySearchHandler.kt
@@ -55,8 +55,10 @@ class ElasticsearchKeySearchHandler(
         response = elasticsearchClient.searchScroll(response)
         scrollIds.add(response.scrollId)
       }
-
-      elasticsearchClient.clearScroll(scrollIds)
+      
+      if (scrollIds.isNotEmpty()) {
+        elasticsearchClient.clearScroll(scrollIds)
+      }
     }
 
     return result

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/ElasticsearchKeySearchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/ElasticsearchKeySearchHandler.kt
@@ -55,7 +55,7 @@ class ElasticsearchKeySearchHandler(
         response = elasticsearchClient.searchScroll(response)
         scrollIds.add(response.scrollId)
       }
-      
+
       if (scrollIds.isNotEmpty()) {
         elasticsearchClient.clearScroll(scrollIds)
       }


### PR DESCRIPTION
Currently clearScroll() is called even if scrollIds is empty.
scrollIds is empty whenever there's no path in a target index.
If no documents are returned then the server should return 200 OK with empty payload.
By calling this method with an empty scrollIds, the response is 500 Internal Server error, which is not intended.
This bugfix prevent calling clearScroll() when scrollIds is empty.