### PR TITLE
feat: add KeyCache interface for checking duplication metric key

### DIFF
--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
@@ -1,0 +1,11 @@
+package com.graphene.writer.store.key
+
+interface KeyCache<K, V> {
+
+  fun get(key: K): V?
+
+  fun putIfAbsent(key: K, value: V): Boolean
+
+  fun put(key: K, value: V): Boolean
+
+}

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
@@ -7,5 +7,4 @@ interface KeyCache<K, V> {
   fun putIfAbsent(key: K, value: V): Boolean
 
   fun put(key: K, value: V): Boolean
-
 }

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/MultiGetRequestContainer.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/MultiGetRequestContainer.kt
@@ -1,0 +1,47 @@
+package com.graphene.writer.store.key
+
+import com.graphene.writer.input.GrapheneMetric
+import org.elasticsearch.action.get.MultiGetRequest
+import java.util.Objects
+
+class MultiGetRequestContainer(
+  val multiGetRequest: MultiGetRequest = MultiGetRequest(),
+  val metrics: MutableMap<Index, GrapheneMetric> = mutableMapOf(),
+  var from: Long? = null,
+  var to: Long? = null
+) {
+
+  fun add(index: String, type: String, metric: GrapheneMetric) {
+    val timestampMillis = metric.timestampMillis()
+
+    multiGetRequest.add(MultiGetRequest.Item(index, type, metric.getId()))
+    metrics["${index}_${metric.getId()}"] = metric
+
+    if (Objects.isNull(from) && Objects.isNull(to)) {
+      from = timestampMillis
+      to = timestampMillis
+    }
+
+    if (timestampMillis < from!!) {
+      from = timestampMillis
+    }
+
+    if (to!! < timestampMillis) {
+      to = timestampMillis
+    }
+  }
+
+  fun size(): Int {
+    return multiGetRequest.items.size
+  }
+
+  fun isMultiGetRequestsExist(): Boolean {
+    return multiGetRequest.items.isNotEmpty()
+  }
+
+  fun multiGetRequestSize(): Int {
+    return multiGetRequest.items.size
+  }
+}
+
+typealias Index = String

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/MultiGetRequestContainer.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/MultiGetRequestContainer.kt
@@ -1,8 +1,8 @@
 package com.graphene.writer.store.key
 
 import com.graphene.writer.input.GrapheneMetric
-import org.elasticsearch.action.get.MultiGetRequest
 import java.util.Objects
+import org.elasticsearch.action.get.MultiGetRequest
 
 class MultiGetRequestContainer(
   val multiGetRequest: MultiGetRequest = MultiGetRequest(),

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/TimeBasedLocalKeyCache.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/TimeBasedLocalKeyCache.kt
@@ -1,0 +1,48 @@
+package com.graphene.writer.store.key
+
+import com.google.common.cache.CacheBuilder
+import com.graphene.common.utils.DateTimeUtils
+import java.util.Objects
+import java.util.concurrent.TimeUnit
+
+/**
+ *
+ * This class is not thread safe.
+ * If you need to handle parallel operation, please consider double-check locking at getOrCreate method.
+ *
+ * @author dark
+ */
+class TimeBasedLocalKeyCache<K, V>(
+  private val expireInterval: Long
+) : KeyCache<K, V> {
+
+  private val internalTimeBasedCache = CacheBuilder.newBuilder()
+    .expireAfterAccess(expireInterval, TimeUnit.MINUTES)
+    .build<Long, MutableMap<K, V>>()
+
+  override fun get(key: K): V? {
+    return getOrCreate()[key]
+  }
+
+  override fun putIfAbsent(key: K, value: V): Boolean {
+    return if (getOrCreate().contains(key)) false
+    else put(key, value)
+  }
+
+  override fun put(key: K, value: V): Boolean {
+    getOrCreate()[key] = value
+    return true
+  }
+
+  private fun getOrCreate(): MutableMap<K, V> {
+    val normalizedTimeBucket = DateTimeUtils.currentTimeMillis() / TimeUnit.MINUTES.toMillis(expireInterval) * TimeUnit.MINUTES.toMillis(expireInterval)
+    var cache = internalTimeBasedCache.getIfPresent(normalizedTimeBucket)
+
+    if (Objects.isNull(cache)) {
+      cache = mutableMapOf()
+      internalTimeBasedCache.put(normalizedTimeBucket, cache)
+    }
+
+    return internalTimeBasedCache.getIfPresent(normalizedTimeBucket)!!
+  }
+}

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
@@ -1,10 +1,10 @@
 package com.graphene.writer.store.key.handler
 
 import com.graphene.writer.store.key.TimeBasedLocalKeyCache
-import org.joda.time.DateTimeUtils
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.joda.time.DateTimeUtils
+import org.junit.jupiter.api.Test
 
 internal class TimeBasedLocalKeyCacheTest {
 

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
@@ -1,0 +1,43 @@
+package com.graphene.writer.store.key.handler
+
+import com.graphene.writer.store.key.TimeBasedLocalKeyCache
+import org.joda.time.DateTimeUtils
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class TimeBasedLocalKeyCacheTest {
+
+  @Test
+  internal fun `should expire cache entry`() {
+    // given
+    val timeBasedCache = TimeBasedLocalKeyCache<String, Long>(1)
+
+    // when
+    DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:00"))
+    timeBasedCache.put(KEY, VALUE)
+
+    // then
+    DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:01:01"))
+    assertNull(timeBasedCache.get(KEY))
+  }
+
+  @Test
+  internal fun `shouldn't expire cache entry not yet expire interval`() {
+    // given
+    val timeBasedCache = TimeBasedLocalKeyCache<String, Long>(1)
+
+    // when
+    DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:00"))
+    timeBasedCache.put(KEY, VALUE)
+
+    // then
+    DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:59"))
+    assertEquals(timeBasedCache.get(KEY), VALUE)
+  }
+
+  companion object {
+    const val KEY = "key1"
+    const val VALUE = 1L
+  }
+}


### PR DESCRIPTION
I have defined an interface and implemented a local cache that can be managed by the time base. Later, you can store the key in the Remote and check for duplicates.