### PR TITLE
feat: add nginx docker image for graphene reader's proxy

### DIFF
--- a/graphene-docker/nginx/1.17.1/Dockerfile
+++ b/graphene-docker/nginx/1.17.1/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.17.1
+
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/graphene-docker/nginx/1.17.1/docker-compose.yml
+++ b/graphene-docker/nginx/1.17.1/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  nginx:
+    image: dark0096/nginx:1.17.1
+    ports:
+      - "80:80"
+    container_name: nginx

--- a/graphene-docker/nginx/1.17.1/nginx.conf
+++ b/graphene-docker/nginx/1.17.1/nginx.conf
@@ -1,0 +1,55 @@
+pid /etc/nginx/nginx.pid;
+
+worker_processes auto;
+events {
+    worker_connections 2048;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    charset utf-8;
+
+    server_tokens off;
+    sendfile on;
+    keepalive_timeout 0;
+
+    gzip on;
+    gzip_http_version 1.1;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_proxied any;
+    gzip_types application/x-javascript application/javascript application/xml text/javascript application/json text/json text/css text/plain application/xhtml+xml application/rss+xml;
+    gzip_buffers 16 8k;
+    gzip_disable "msie6";
+
+    upstream backend_server {
+        server 127.0.0.1:8080;
+    }
+
+    server {
+        listen 80 default_server;
+        root /tmp;
+
+        location / {
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_intercept_errors off;
+            proxy_connect_timeout 10;
+            proxy_send_timeout 10;
+            proxy_read_timeout 60;
+            proxy_buffer_size 8k;
+            proxy_buffers 10 512k;
+            proxy_busy_buffers_size 512k;
+            proxy_temp_file_write_size 512k;
+
+            proxy_pass http://backend_server;
+        }
+    }
+}


### PR DESCRIPTION
Nginx is a popular tool for serving HTTP. Graphene reader provides a lot of timeseries with metric datapoints. Most timeseries often have no data if you query for long time range. These parts can be easily handled through Nginx compression.