### PR TITLE
feature: added dynamic template to store each key's parts in keyword type

### DIFF
--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
@@ -30,7 +30,6 @@ class IndexBasedKeyStoreHandler(
 
     val source = XContentFactory.jsonBuilder()
       .startObject()
-      .field(TENANT, metric.getTenant())
       .field(DEPTH, graphiteKeyParts.size)
       .field(LEAF, true)
 
@@ -42,7 +41,6 @@ class IndexBasedKeyStoreHandler(
   }
 
   companion object {
-    const val TENANT = "tenant"
     const val DEPTH = "depth"
     const val LEAF = "leaf"
 

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
@@ -53,6 +53,40 @@ class IndexBasedKeyStoreHandler(
           "number_of_replicas": 0,
           "number_of_shards": 5,
           "auto_expand_replicas": "0-1"
+        },
+        "mappings": {
+          "path": {
+            "dynamic_templates": [
+              {
+                "leaf": {
+                  "match": "leaf",
+                  "match_mapping_type": "boolean",
+                  "mapping": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              {
+                "depth": {
+                  "match": "depth",
+                  "match_mapping_type": "long",
+                  "mapping": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "else": {
+                  "match": "*",
+                  "unmatch": "depth",
+                  "match_mapping_type": "string",
+                  "mapping": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            ]
+          }
         }
       }
     """


### PR DESCRIPTION
Currently string data type is stored in ES with two types: keyword and text.
To be able to search mappings, the fields should be mapped to keyword only.
This index template uses dynamic template to match fields other than "depth" and maps the values in keyword data type.
