### PR TITLE
bugfix: Several bugs are patched.

### DIFF
--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizer.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizer.kt
@@ -27,9 +27,6 @@ class ElasticsearchIntegratedTagSearchQueryOptimizer : ElasticsearchTagSearchQue
       if (isValidTagExpression(tagExpressionParts)) {
         val head = tagExpressionParts[0]
         val tail = tagExpressionParts[1]
-        if (tail == ASTERISK) {
-          continue
-        }
         var tagKey = head
         var tagValue = tail
         when {
@@ -37,6 +34,10 @@ class ElasticsearchIntegratedTagSearchQueryOptimizer : ElasticsearchTagSearchQue
         }
         when {
           isStartWithTilde(tail) -> tagValue = tail.substring(1, tail.length)
+        }
+        if (tagValue == ASTERISK) {
+          boolQuery.filter(QueryBuilders.existsQuery(tagKey))
+          continue
         }
 
         when {
@@ -116,12 +117,12 @@ class ElasticsearchIntegratedTagSearchQueryOptimizer : ElasticsearchTagSearchQue
 
   private fun getEscapedExpression(expr: String): String {
     return expr.replace(".", "\\.")
-      .replace("*", "[^\\.]*")
       .replace("{", "(")
       .replace("{", "(")
       .replace("}", ")")
       .replace(",", "|")
       .replace("?", "[^\\.]")
+      .replace("*", ".*")
   }
 
   companion object {

--- a/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizerTest.kt
+++ b/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizerTest.kt
@@ -241,7 +241,7 @@ internal class ElasticsearchIntegratedTagSearchQueryOptimizerTest {
           {
             "regexp" : {
               "dc" : {
-                "value" : "a[^\\.]*",
+                "value" : "a.*",
                 "flags_value" : 65535,
                 "max_determinized_states" : 10000,
                 "boost" : 1.0

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/AbstractElasticsearchKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/AbstractElasticsearchKeyStoreHandler.kt
@@ -78,7 +78,7 @@ abstract class AbstractElasticsearchKeyStoreHandler(
       val metricsList = mutableListOf<GrapheneMetric>()
       metrics.drainTo(metricsList)
       for (metric in metricsList) {
-        if (Objects.nonNull(metric)) {
+        if (Objects.nonNull(metric) && isProcessable(metric)) {
           addToBatch(metric)
         }
       }
@@ -145,6 +145,8 @@ abstract class AbstractElasticsearchKeyStoreHandler(
     } catch (ignored: InterruptedException) {
     }
   }
+
+  abstract fun isProcessable(metric: GrapheneMetric): Boolean
 
   abstract fun mapToGrapheneIndexRequests(metric: GrapheneMetric?): List<GrapheneIndexRequest>
 

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/IndexBasedKeyStoreHandler.kt
@@ -1,10 +1,10 @@
 package com.graphene.writer.store.key.handler
 
 import com.graphene.writer.input.GrapheneMetric
+import com.graphene.writer.input.Source
 import com.graphene.writer.store.key.ElasticsearchClientFactory
 import com.graphene.writer.store.key.GrapheneIndexRequest
 import com.graphene.writer.store.key.KeyStoreHandlerProperty
-import java.util.Collections
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentFactory
 
@@ -19,11 +19,12 @@ class IndexBasedKeyStoreHandler(
   val property: KeyStoreHandlerProperty
 ) : AbstractElasticsearchKeyStoreHandler(elasticsearchClientFactory, property) {
 
+  override fun isProcessable(metric: GrapheneMetric): Boolean {
+    return metric.source == Source.GRAPHITE
+  }
+
   override fun mapToGrapheneIndexRequests(metric: GrapheneMetric?): List<GrapheneIndexRequest> {
-    if (! metric!!.tags.isNullOrEmpty()) {
-      return Collections.emptyList<GrapheneIndexRequest>()
-    }
-    return mutableListOf(GrapheneIndexRequest(metric.id!!, source(metric), metric.timestampMillis()))
+    return mutableListOf(GrapheneIndexRequest(metric!!.id!!, source(metric), metric.timestampMillis()))
   }
 
   override fun templateSource(): String = SOURCE

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/SimpleKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/SimpleKeyStoreHandler.kt
@@ -1,6 +1,7 @@
 package com.graphene.writer.store.key.handler
 
 import com.graphene.writer.input.GrapheneMetric
+import com.graphene.writer.input.Source
 import com.graphene.writer.store.key.ElasticsearchClientFactory
 import com.graphene.writer.store.key.GrapheneIndexRequest
 import com.graphene.writer.store.key.KeyStoreHandlerProperty
@@ -20,13 +21,13 @@ class SimpleKeyStoreHandler(
   val property: KeyStoreHandlerProperty
 ) : AbstractElasticsearchKeyStoreHandler(elasticsearchClientFactory, property) {
 
-  override fun mapToGrapheneIndexRequests(metric: GrapheneMetric?): List<GrapheneIndexRequest> {
-    if (Objects.isNull(metric) || ! metric!!.tags.isNullOrEmpty()) {
-      return Collections.emptyList<GrapheneIndexRequest>()
-    }
+  override fun isProcessable(metric: GrapheneMetric): Boolean {
+    return metric.source == Source.GRAPHITE
+  }
 
+  override fun mapToGrapheneIndexRequests(metric: GrapheneMetric?): List<GrapheneIndexRequest> {
     val grapheneIndexRequests = mutableListOf<GrapheneIndexRequest>()
-    val nodes = metric.nodes
+    val nodes = metric!!.nodes
     val graphiteKeySb = StringBuilder()
 
     for (indexedValue in nodes.entries.withIndex()) {

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/SimpleKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/SimpleKeyStoreHandler.kt
@@ -5,8 +5,6 @@ import com.graphene.writer.input.Source
 import com.graphene.writer.store.key.ElasticsearchClientFactory
 import com.graphene.writer.store.key.GrapheneIndexRequest
 import com.graphene.writer.store.key.KeyStoreHandlerProperty
-import java.util.Collections
-import java.util.Objects
 import java.util.TreeMap
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentFactory

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/TagBasedKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/handler/TagBasedKeyStoreHandler.kt
@@ -22,6 +22,14 @@ class TagBasedKeyStoreHandler(
 
   private val log = LogManager.getLogger(javaClass)
 
+  override fun isProcessable(metric: GrapheneMetric): Boolean {
+    if (Source.GRAPHITE == metric.source) {
+      log.warn("Please change store handler to simple or index-based key store handler because TagBasedKeyStoreHandler does not support the old graphite format.")
+      return false
+    }
+    return true
+  }
+
   override fun mapToGrapheneIndexRequests(metric: GrapheneMetric?): List<GrapheneIndexRequest> {
     if (Source.GRAPHITE == metric!!.source) {
       log.warn("Please change store handler to simple or index-based key store handler because TagBasedKeyStoreHandler does not support the old graphite format.")


### PR DESCRIPTION
- ElasticsearchIntegratedTagSearchQueryOptimizer
  * If value is ASTERISK then it can be omitted but has to exist. Patch covers this case.
  * Removed squared brackets when escaping regex patterns for *. * -> .* is enough.
- AbstractElasticsearchKeyStoreHandler
  * Added abstract method 'isProcessable' because the system doesn't have to add metrics to multiGetRequestContainer even if it's not the type of metric for the implementations. Currently all the metrics are added to each implementation's multiGetRequestContainer, which causes to send unnecessary requests to ES.