### PR TITLE
feature: including all option on tag value whenever result set is not empty

### DIFF
--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandler.kt
@@ -60,6 +60,9 @@ class ElasticsearchTagSearchHandler(
     } catch (e: Exception) {
       logger.warn("Failed to find Tag Values: {tag: $tag}, {valuePrefix: $valuePrefix}, {tagExpressions: $tagExpressions}")
     }
+    if (tagValues.size > 0) {
+      tagValues.add("*")
+    }
     return tagValues.sorted()
   }
 

--- a/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
+++ b/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
@@ -5,9 +5,9 @@ import com.graphene.reader.store.tag.elasticsearch.optimizer.ElasticsearchIntegr
 import com.graphene.reader.utils.ElasticsearchTestUtils
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.test.assertEquals
 import org.elasticsearch.search.SearchHits
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 internal class ElasticsearchTagSearchHandlerTest {
 
@@ -31,7 +31,7 @@ internal class ElasticsearchTagSearchHandlerTest {
       )
 
     // then
-    assertEquals( 2, result.size )
+    assertEquals(2, result.size)
     assertEquals("*", result[0])
   }
 
@@ -52,6 +52,6 @@ internal class ElasticsearchTagSearchHandlerTest {
       )
 
     // then
-    assertEquals( 0, result.size )
+    assertEquals(0, result.size)
   }
 }

--- a/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
+++ b/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.graphene.reader.store.tag.elasticsearch
+
+import com.graphene.reader.store.key.elasticsearch.handler.ElasticsearchClient
+import com.graphene.reader.store.tag.elasticsearch.optimizer.ElasticsearchIntegratedTagSearchQueryOptimizer
+import com.graphene.reader.utils.ElasticsearchTestUtils
+import io.mockk.every
+import io.mockk.mockk
+import org.elasticsearch.search.SearchHits
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class ElasticsearchTagSearchHandlerTest {
+
+  private val elasticsearchClient = mockk<ElasticsearchClient>()
+  private val elasticsearchTagSearchHandler = ElasticsearchTagSearchHandler(elasticsearchClient, ElasticsearchIntegratedTagSearchQueryOptimizer())
+
+  @Test
+  internal fun `should return all option (*) whenever result is not empty`() {
+    // given
+    val response = ElasticsearchClient.Response("", SearchHits.empty(), 0, mutableSetOf("a"))
+
+    every { elasticsearchClient.query(any(), any(), any(), any(), any()) } answers { response }
+    every { elasticsearchClient.searchScroll(any()) } answers { ElasticsearchTestUtils.emptyResponse() }
+    every { elasticsearchClient.clearScroll(any()) } answers { Unit }
+
+    // when
+
+    val result = elasticsearchTagSearchHandler
+      .getTagValues(
+        "", mutableListOf(), "a", 0, 10, 10
+      )
+
+    // then
+    assertEquals( 2, result.size )
+    assertEquals("*", result[0])
+  }
+
+  @Test
+  internal fun `should not return all option (*) whenever result is empty`() {
+    // given
+    val response = ElasticsearchClient.Response("", SearchHits.empty(), 0, mutableSetOf())
+
+    every { elasticsearchClient.query(any(), any(), any(), any(), any()) } answers { response }
+    every { elasticsearchClient.searchScroll(any()) } answers { ElasticsearchTestUtils.emptyResponse() }
+    every { elasticsearchClient.clearScroll(any()) } answers { Unit }
+
+    // when
+
+    val result = elasticsearchTagSearchHandler
+      .getTagValues(
+        "", mutableListOf(), "a", 0, 10, 10
+      )
+
+    // then
+    assertEquals( 0, result.size )
+  }
+}


### PR DESCRIPTION
Related issue: https://github.com/graphene-monitoring/graphene/issues/52
Including all option(*) on tag value set whenever result set is not empty.
