### PR TITLE
feature: improved key cache

### DIFF
--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/KeyCache.kt
@@ -1,10 +1,10 @@
 package com.graphene.writer.store.key
 
-interface KeyCache<K, V> {
+interface KeyCache<K> {
 
-  fun get(key: K): V?
+  fun get(key: K): K?
 
-  fun putIfAbsent(key: K, value: V): Boolean
+  fun putIfAbsent(key: K): Boolean
 
-  fun put(key: K, value: V): Boolean
+  fun put(key: K): Boolean
 }

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/SimpleLocalKeyCache.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/SimpleLocalKeyCache.kt
@@ -1,0 +1,39 @@
+package com.graphene.writer.store.key
+
+import com.google.common.cache.CacheBuilder
+import java.util.Objects
+import java.util.concurrent.TimeUnit
+
+/**
+ *
+ * This class is not thread safe.
+ * If you need to handle parallel operation, please consider double-check locking at getOrCreate method.
+ *
+ * @author jerome89
+ */
+class SimpleLocalKeyCache<K>(
+  expireInterval: Long
+) : KeyCache<K> {
+  private val internalSimpleCache = CacheBuilder.newBuilder()
+    .expireAfterAccess(expireInterval, TimeUnit.MINUTES)
+    .build<K, Byte>()
+
+  override fun get(key: K): K? {
+    return if (Objects.nonNull(internalSimpleCache.getIfPresent(key))) key
+    else null
+  }
+
+  override fun putIfAbsent(key: K): Boolean {
+    val cacheEntry = internalSimpleCache.getIfPresent(key)
+    if (Objects.isNull(cacheEntry)) {
+      internalSimpleCache.put(key, 0.toByte())
+      return true
+    }
+    return false
+  }
+
+  override fun put(key: K): Boolean {
+    internalSimpleCache.put(key, 0.toByte())
+    return true
+  }
+}

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/elasticsearch/handler/AbstractElasticsearchKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/elasticsearch/handler/AbstractElasticsearchKeyStoreHandler.kt
@@ -6,7 +6,7 @@ import com.graphene.writer.input.GrapheneMetric
 import com.graphene.writer.store.KeyStoreHandler
 import com.graphene.writer.store.KeyStoreHandlerProperty
 import com.graphene.writer.store.key.KeyCache
-import com.graphene.writer.store.key.TimeBasedLocalKeyCache
+import com.graphene.writer.store.key.SimpleLocalKeyCache
 import com.graphene.writer.store.key.elasticsearch.ElasticsearchClient
 import com.graphene.writer.store.key.elasticsearch.ElasticsearchClientFactory
 import com.graphene.writer.store.key.elasticsearch.GrapheneIndexRequest
@@ -42,7 +42,7 @@ abstract class AbstractElasticsearchKeyStoreHandler(
   private var flushInterval: Long = 0
 
   private val metrics = LinkedBlockingDeque<GrapheneMetric>()
-  private val keyCache: KeyCache<String, GrapheneMetric> = TimeBasedLocalKeyCache(5) // Default 5 Min
+  private val keyCache: KeyCache<String> = SimpleLocalKeyCache(5) // Default 5 Min
 
   init {
     val property = Jsons.from(keyStoreHandlerProperty.handler["property"], ElasticsearchKeyStoreHandlerProperty::class.java)
@@ -94,7 +94,7 @@ abstract class AbstractElasticsearchKeyStoreHandler(
 
   private fun addToBatch(metric: GrapheneMetric) {
     val index = elasticsearchClient.getIndexWithDate(index, tenant, metric.timestampMillis())
-    if (keyCache.putIfAbsent("${index}_${metric.id}", metric)) {
+    if (keyCache.putIfAbsent("${index}_${metric.id}")) {
       multiGetRequestContainer.add(index, type, metric)
     }
   }

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/SimpleLocalKeyCacheTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/SimpleLocalKeyCacheTest.kt
@@ -1,0 +1,50 @@
+package com.graphene.writer.store.key.handler
+
+import com.graphene.writer.store.key.SimpleLocalKeyCache
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+internal class SimpleLocalKeyCacheTest {
+
+  @Test
+  internal fun `should return null if there's no key in cache`() {
+    // given
+    val simpleCache = SimpleLocalKeyCache<String>(1)
+
+    // when
+    // nothing
+
+    // then
+    assertNull(simpleCache.get(KEY))
+  }
+
+  @Test
+  internal fun `should return false if key is already in cache`() {
+    // given
+    val timeBasedCache = SimpleLocalKeyCache<String>(1)
+
+    // when
+    timeBasedCache.put(KEY)
+
+    // then
+    assertFalse(timeBasedCache.putIfAbsent(KEY))
+  }
+
+  @Test
+  internal fun `should return key if key is in cache`() {
+    // given
+    val timeBasedCache = SimpleLocalKeyCache<String>(1)
+
+    // when
+    timeBasedCache.put(KEY)
+
+    // then
+    assertEquals(timeBasedCache.get(KEY), KEY)
+  }
+
+  companion object {
+    const val KEY = "key1"
+  }
+}

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/key/handler/TimeBasedLocalKeyCacheTest.kt
@@ -11,11 +11,11 @@ internal class TimeBasedLocalKeyCacheTest {
   @Test
   internal fun `should expire cache entry`() {
     // given
-    val timeBasedCache = TimeBasedLocalKeyCache<String, Long>(1)
+    val timeBasedCache = TimeBasedLocalKeyCache<String>(1)
 
     // when
     DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:00"))
-    timeBasedCache.put(KEY, VALUE)
+    timeBasedCache.put(KEY)
 
     // then
     DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:01:01"))
@@ -25,19 +25,18 @@ internal class TimeBasedLocalKeyCacheTest {
   @Test
   internal fun `shouldn't expire cache entry not yet expire interval`() {
     // given
-    val timeBasedCache = TimeBasedLocalKeyCache<String, Long>(1)
+    val timeBasedCache = TimeBasedLocalKeyCache<String>(1)
 
     // when
     DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:00"))
-    timeBasedCache.put(KEY, VALUE)
+    timeBasedCache.put(KEY)
 
     // then
     DateTimeUtils.setCurrentMillisFixed(com.graphene.common.utils.DateTimeUtils.from("2019-01-01 10:00:59"))
-    assertEquals(timeBasedCache.get(KEY), VALUE)
+    assertEquals(timeBasedCache.get(KEY), KEY)
   }
 
   companion object {
     const val KEY = "key1"
-    const val VALUE = 1L
   }
 }


### PR DESCRIPTION
Current key cache implementation(TimeBasedLocalKeyCache) used in AbstractElasticsearchKeyStoreHandler stores quite heavy objects(GrapheneMetric) in cache even if it is not being used.

This PR changes its implementation not to store those objects in cache, and introduces SimpleLocalKeyCache which is more lighter than TimeBasedLocalKeyCache. The implementation of SimpleLocalKeyCache is simply using Guava cache directly. Expiration is automatically done by the library, and does not create time bucket to avoid to store duplicate entries in cache. Because of this, memory consumption of cache is much less than TimeBasedLocalKeyCache, and cache hit rate will increase because it does not manage set of cache entries created by time.

I've got some benefits from this cache implementation under write intensive workload.