### PR TITLE
feature: configurable resolution(rollup)

### DIFF
--- a/graphene-common/src/main/kotlin/com/graphene/common/beans/SeriesRange.kt
+++ b/graphene-common/src/main/kotlin/com/graphene/common/beans/SeriesRange.kt
@@ -9,6 +9,6 @@ class SeriesRange(from: Long, to: Long, val rollup: Int) {
   }
 
   init {
-    this.expectedCount = (this.to - this.from).toInt() / rollup + 1
+    this.expectedCount = ((this.to - this.from) / rollup + 1).toInt()
   }
 }

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/error/exception/GrapheneReaderException.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/error/exception/GrapheneReaderException.kt
@@ -8,4 +8,6 @@ class UnsupportedKeySearchHandlerException(message: String) : GrapheneReaderExce
 
 class UnsupportedDataFetchHandlerException(message: String) : GrapheneReaderException(message)
 
+class UnsupportedRollupException(message: String) : GrapheneReaderException(message)
+
 class IllegalArgumentException(message: String) : GrapheneReaderException(message)

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/DataFetchHandlerConfig.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/DataFetchHandlerConfig.kt
@@ -60,7 +60,7 @@ data class DataFetchHandlerProperty(
   var columnFamily: String,
   var rollup: Int = 60,
   var maxPoints: Int = Int.MAX_VALUE,
-  var bucketSize: Int,
+  var bucketSize: Short,
   var property: CassandraDataHandlerProperty
 )
 

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/OffsetBasedDataFetchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/OffsetBasedDataFetchHandler.kt
@@ -38,27 +38,27 @@ class OffsetBasedDataFetchHandler(
   dataFetchHandlerProperty: DataFetchHandlerProperty
 ) : DataFetchHandler {
 
-  val query: String = """
+  private val query: String
+  private var rollup: Int = 60
+  private var cluster: Cluster = cassandraFactory.createCluster(dataFetchHandlerProperty.property)
+  private var session: Session
+  private var statement: PreparedStatement
+  private var maxPoints: Int = Int.MAX_VALUE
+  private var bucketSize: Int = 604800
+
+  init {
+    this.rollup = dataFetchHandlerProperty.rollup
+    this.query = """
     SELECT offset, data
-        FROM ${dataFetchHandlerProperty.keyspace}.${dataFetchHandlerProperty.columnFamily}_${dataFetchHandlerProperty.bucketSize}
+        FROM ${dataFetchHandlerProperty.keyspace}_${dataFetchHandlerProperty.bucketSize}.${dataFetchHandlerProperty.columnFamily}_${rollup}s
         WHERE path = ?
               AND tenant = ?
               AND startTime = ?
               AND offset >= ?
               AND offset <= ?
         ORDER BY offset;"""
-
-  private var cluster: Cluster = cassandraFactory.createCluster(dataFetchHandlerProperty.property)
-  private var session: Session
-  private var statement: PreparedStatement
-  private var rollup: Int = 60
-  private var maxPoints: Int = Int.MAX_VALUE
-  private var bucketSize: Int = 604800
-
-  init {
     this.session = cluster.connect()
     this.statement = session.prepare(query)
-    this.rollup = dataFetchHandlerProperty.rollup
     this.maxPoints = dataFetchHandlerProperty.maxPoints
     this.bucketSize = dataFetchHandlerProperty.bucketSize
   }
@@ -138,7 +138,7 @@ class OffsetBasedDataFetchHandler(
     val from = seriesRange.from
     val to = seriesRange.to
     val rollup = seriesRange.rollup
-    var startTime = from - from % bucketSize
+    var startTime = from - from % (bucketSize * rollup)
     val queryOffsetRange = Maps.newTreeMap<Long, OffsetRange>()
     while (startTime <= to) {
       val offsetRange = OffsetRange()
@@ -147,13 +147,13 @@ class OffsetBasedDataFetchHandler(
       } else {
         offsetRange.startOffset = 0
       }
-      if (startTime + bucketSize < to) {
-        offsetRange.endOffset = ((bucketSize / rollup) - 1).toShort()
+      if (startTime + (bucketSize * rollup) < to) {
+        offsetRange.endOffset = (((bucketSize * rollup) / rollup) - 1).toShort()
       } else {
         offsetRange.endOffset = ((to - startTime) / rollup).toShort()
       }
       queryOffsetRange[startTime] = offsetRange
-      startTime += bucketSize
+      startTime += (bucketSize * rollup)
     }
     return queryOffsetRange
   }

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/OffsetBasedDataFetchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/OffsetBasedDataFetchHandler.kt
@@ -45,7 +45,7 @@ class OffsetBasedDataFetchHandler(
   private var session: Session
   private var statement: PreparedStatement
   private var maxPoints: Int = Int.MAX_VALUE
-  private var bucketSize: Int = 604800
+  private var bucketSize: Long = 30000L
 
   init {
     this.rollup = dataFetchHandlerProperty.rollup
@@ -62,7 +62,7 @@ class OffsetBasedDataFetchHandler(
     this.session = cluster.connect()
     this.statement = session.prepare(query)
     this.maxPoints = dataFetchHandlerProperty.maxPoints
-    this.bucketSize = dataFetchHandlerProperty.bucketSize
+    this.bucketSize = dataFetchHandlerProperty.bucketSize.toLong()
   }
 
   private fun executeAsync(path: String, tenant: String, startTime: Long, startOffset: Short, endOffset: Short): ResultSetFuture {
@@ -139,8 +139,8 @@ class OffsetBasedDataFetchHandler(
   fun createQueryOffsetRanges(seriesRange: SeriesRange): Map<Long, OffsetRange> {
     val from = seriesRange.from
     val to = seriesRange.to
-    val rollup = seriesRange.rollup
-    var startTime = from - from % (bucketSize * rollup)
+    val rollup = seriesRange.rollup.toLong()
+    var startTime: Long = from - from % (bucketSize * rollup)
     val queryOffsetRange = Maps.newTreeMap<Long, OffsetRange>()
     while (startTime <= to) {
       val offsetRange = OffsetRange()

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/SimpleDataFetchHandler.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/data/cassandra/handler/SimpleDataFetchHandler.kt
@@ -15,6 +15,7 @@ import com.graphene.common.beans.Path
 import com.graphene.common.beans.SeriesRange
 import com.graphene.common.store.data.cassandra.CassandraFactory
 import com.graphene.reader.beans.TimeSeries
+import com.graphene.reader.error.exception.UnsupportedRollupException
 import com.graphene.reader.exceptions.TooMuchDataExpectedException
 import com.graphene.reader.service.metric.DataFetchHandler
 import com.graphene.reader.store.data.DataFetchHandlerProperty
@@ -45,6 +46,7 @@ class SimpleDataFetchHandler(
 
   init {
     this.rollup = dataFetchHandlerProperty.rollup
+    validateRollup(rollup)
     this.query = """
     SELECT time, data
     FROM ${dataFetchHandlerProperty.keyspace}.${dataFetchHandlerProperty.columnFamily}_${rollup}s
@@ -127,6 +129,13 @@ class SimpleDataFetchHandler(
 
   override fun getRollup(): Int {
     return rollup
+  }
+
+  private fun validateRollup(rollup: Int) {
+    if (rollup <= 0) {
+      throw UnsupportedRollupException("Rollup is $rollup <= 0!. It should be greater than 0.")
+    }
+    OffsetBasedDataFetchHandler.logger.info("Rollup: $rollup")
   }
 
   @PreDestroy

--- a/graphene-reader/src/main/resources/application.yml
+++ b/graphene-reader/src/main/resources/application.yml
@@ -88,7 +88,7 @@ graphene:
             maxPoints: 60000000
             keyspace: "metric_offset"
             columnFamily: "metric"
-            bucketSize: 604800
+            bucketSize: 30000
             rollup: 60
             property:
               cluster:

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/domain/Metric.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/domain/Metric.kt
@@ -23,7 +23,7 @@ class Metric {
   val timestamp: Long
     get() = key!!.timestamp
 
-  constructor(input: String, rollup: Int) {
+  constructor(input: String) {
     val splitInput = input.split("\\s".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
     // We were interning tenant and path here - we are going to store them all (or almost so) constantly anyhow in multiple places
     // In fact this also work for a moderate metrics stream. Once we start receiving 10s of millions different metrics, it tends to degrade quite a bit
@@ -31,12 +31,8 @@ class Metric {
     this.key = MetricKey(
       if (splitInput.size >= 4) splitInput[3].intern() else MetricRule.defaultTenant(),
       splitInput[0],
-      normalizeTimestamp(java.lang.Long.parseLong(splitInput[2]), rollup))
+      java.lang.Long.parseLong(splitInput[2]))
     this.value = java.lang.Double.parseDouble(splitInput[1])
-  }
-
-  private fun normalizeTimestamp(timestamp: Long, rollup: Int): Long {
-    return timestamp / rollup * rollup
   }
 
   override fun toString(): String {

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/error/exception/GrapheneWriterException.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/error/exception/GrapheneWriterException.kt
@@ -8,4 +8,6 @@ class UnsupportedKeyStoreHandlerException(message: String) : GrapheneWriterExcep
 
 class UnsupportedDataStoreHandlerException(message: String) : GrapheneWriterException(message)
 
+class UnsupportedRollupException(message: String) : GrapheneWriterException(message)
+
 class IllegalArgumentException(message: String) : GrapheneWriterException(message)

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/input/graphite/property/InputGraphiteCarbonProperty.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/input/graphite/property/InputGraphiteCarbonProperty.kt
@@ -13,7 +13,6 @@ class InputGraphiteCarbonProperty {
 
   var bind: String? = null
   var port: Int = 0
-  var rollup: Int = 60
   var route: Route? = null
 
   @PostConstruct
@@ -25,7 +24,6 @@ class InputGraphiteCarbonProperty {
     return "InputGraphiteCarbonProperty{" +
       "bind='" + bind + '\''.toString() +
       ", port=" + port +
-      ", rollups=" + this.rollup +
       '}'.toString()
   }
 

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/StoreHandlerFactory.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/StoreHandlerFactory.kt
@@ -129,7 +129,7 @@ data class DataStoreHandlerProperty(
   var rollup: Int = 60,
   var keyspace: String,
   var columnFamily: String,
-  var bucketSize: Int,
+  var bucketSize: Short,
   var property: CassandraDataHandlerProperty
 )
 

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/StoreHandlerFactory.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/StoreHandlerFactory.kt
@@ -126,6 +126,7 @@ data class DataStoreHandlerProperty(
   var type: String,
   var tenant: String = GrapheneRules.DEFAULT_TENANT,
   var ttl: Int = 0,
+  var rollup: Int = 60,
   var keyspace: String,
   var columnFamily: String,
   var bucketSize: Int,

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandler.kt
@@ -9,6 +9,7 @@ import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.MoreExecutors
 import com.graphene.common.store.data.cassandra.CassandraFactory
+import com.graphene.writer.error.exception.UnsupportedRollupException
 import com.graphene.writer.input.GrapheneMetric
 import com.graphene.writer.store.DataStoreHandler
 import com.graphene.writer.store.DataStoreHandlerProperty
@@ -34,7 +35,7 @@ class OffsetBasedDataStoreHandler(
   // bucketSize: range of short data type 0 ~ 32767
   // rollup should divide 60 or divided by 60
   var rollup: Int = 60
-  private var query: String
+  var query: String
   private var cluster: Cluster = cassandraFactory.createCluster(dataStoreHandlerProperty.property)
   private var session: Session
   private var statement: PreparedStatement
@@ -84,12 +85,12 @@ class OffsetBasedDataStoreHandler(
     )
   }
 
-  private fun getStartTime(timestamp: Long): Long {
+  fun getStartTime(timestamp: Long): Long {
     val remainder = timestamp % (bucketSize * rollup)
     return timestamp - remainder
   }
 
-  private fun getOffset(timestamp: Long): Short {
+  fun getOffset(timestamp: Long): Short {
     val remainder = timestamp % (bucketSize * rollup)
     return (remainder / rollup).toShort()
   }
@@ -118,12 +119,8 @@ class OffsetBasedDataStoreHandler(
   }
 
   private fun validateRollup(rollup: Int) {
-    if (rollup <= 60 && 60 % rollup != 0) {
-      throw Exception("Rollup is $rollup <= 60!. It should divide 60.")
-    } else if (rollup > 60 && rollup % 60 != 0) {
-      throw Exception("Rollup is $rollup > 60!. It should be divided by 60.")
-    } else if (rollup <= 0) {
-      throw Exception("Rollup is $rollup <= 0!. It should be greater than 0.")
+    if (rollup <= 0) {
+      throw UnsupportedRollupException("Rollup is $rollup <= 0!. It should be greater than 0.")
     }
     logger.info("Rollup: $rollup")
   }

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandler.kt
@@ -31,7 +31,7 @@ class OffsetBasedDataStoreHandler(
 
   private val logger = LogManager.getLogger(OffsetBasedDataStoreHandler::class.java)
   private val ttl = dataStoreHandlerProperty.ttl
-  private val bucketSize = dataStoreHandlerProperty.bucketSize
+  private val bucketSize = dataStoreHandlerProperty.bucketSize.toLong()
   // bucketSize: range of short data type 0 ~ 32767
   // rollup should divide 60 or divided by 60
   var rollup: Int = 60

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/SimpleDataStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/data/cassandra/handler/SimpleDataStoreHandler.kt
@@ -9,6 +9,7 @@ import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.MoreExecutors
 import com.graphene.common.store.data.cassandra.CassandraFactory
+import com.graphene.writer.error.exception.UnsupportedRollupException
 import com.graphene.writer.input.GrapheneMetric
 import com.graphene.writer.store.DataStoreHandler
 import com.graphene.writer.store.DataStoreHandlerProperty
@@ -28,7 +29,7 @@ class SimpleDataStoreHandler(
   dataStoreHandlerProperty: DataStoreHandlerProperty
 ) : DataStoreHandler {
 
-  private val query: String
+  val query: String
   private var rollup: Int = 60
   private val logger = LogManager.getLogger(SimpleDataStoreHandler::class.java)
   private val ttl = dataStoreHandlerProperty.ttl
@@ -108,12 +109,8 @@ class SimpleDataStoreHandler(
   }
 
   private fun validateRollup(rollup: Int) {
-    if (rollup <= 60 && 60 % rollup != 0) {
-      throw Exception("Rollup is $rollup <= 60!. It should divide 60.")
-    } else if (rollup > 60 && rollup % 60 != 0) {
-      throw Exception("Rollup is $rollup > 60!. It should be divided by 60.")
-    } else if (rollup <= 0) {
-      throw Exception("Rollup is $rollup <= 0!. It should be greater than 0.")
+    if (rollup <= 0) {
+      throw UnsupportedRollupException("Rollup is $rollup <= 0!. It should be greater than 0.")
     }
     logger.info("Rollup: $rollup")
   }

--- a/graphene-writer/src/main/resources/application.yml
+++ b/graphene-writer/src/main/resources/application.yml
@@ -15,7 +15,6 @@ graphene:
         carbon:
           bind: "0.0.0.0"
           port: 2003
-          rollup: 60
   #        route:
   #          host: 127.0.0.1
   #          port: 2003
@@ -91,7 +90,7 @@ graphene:
           tag-based-key-store-handler:
             tenant: none
             rotation:
-              strategy: "timeBasedRotation"
+              strategy: "noOpRotation"
               period: "1w"
             handler:
               type: "TagBasedKeyStoreHandler"
@@ -111,6 +110,7 @@ graphene:
             type: "SimpleDataStoreHandler"
             tenant: NONE
             ttl: 604800
+            rollup: 60
             keyspace: "metric"
             columnFamily: "metric"
             bucketSize: 0
@@ -132,9 +132,10 @@ graphene:
             type: "OffsetBasedDataStoreHandler"
             tenant: NONE
             ttl: 604800
+            rollup: 60
             keyspace: "metric_offset"
             columnFamily: "metric"
-            bucketSize: 604800
+            bucketSize: 30000
             property:
               cluster:
                 - "127.0.0.1"

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandlerTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/data/cassandra/handler/OffsetBasedDataStoreHandlerTest.kt
@@ -1,0 +1,137 @@
+package com.graphene.writer.store.data.cassandra.handler
+
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.PreparedStatement
+import com.datastax.driver.core.Session
+import com.graphene.common.store.data.cassandra.CassandraFactory
+import com.graphene.common.store.data.cassandra.property.CassandraDataHandlerProperty
+import com.graphene.writer.store.DataStoreHandlerProperty
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+internal class OffsetBasedDataStoreHandlerTest {
+  private lateinit var offsetBasedDataStoreHandler: OffsetBasedDataStoreHandler
+  private val cassandraFactory: CassandraFactory = mockk()
+  private val cluster: Cluster = mockk()
+  private val session: Session = mockk()
+  private val preparedStatement: PreparedStatement = mockk()
+
+  @Test
+  internal fun `should query to proper keyspace, table with given bucketSize = 150 and rollup = 15`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "OffsetBasedDataStoreHandler",
+      ttl = 60,
+      rollup = 15,
+      tenant = "NONE",
+      bucketSize = 150,
+      columnFamily = "metric",
+      keyspace = "metric_offset",
+      property = CassandraDataHandlerProperty()
+    )
+    val query = """
+          UPDATE metric_offset_150.metric_15s
+          USING TTL ?
+          SET data = ?
+          WHERE tenant = ?
+                AND path = ?
+                AND startTime = ?
+                AND offset = ?;
+    """.trimIndent()
+
+    every { cassandraFactory.createCluster(any()) } answers { cluster }
+    every { cluster.connect() } answers { session }
+    every { session.prepare(any() as String) } answers { preparedStatement }
+
+    // when
+    offsetBasedDataStoreHandler = OffsetBasedDataStoreHandler(
+      cassandraFactory,
+      dataStoreHandlerProperty
+    )
+
+    // then
+    assertEquals(query, offsetBasedDataStoreHandler.query.trimIndent())
+  }
+
+  @Test
+  internal fun `should not throw exception when rollup is greater than 0`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "OffsetBasedDataStoreHandler",
+      ttl = 60,
+      rollup = 120,
+      tenant = "NONE",
+      bucketSize = 150,
+      columnFamily = "metric",
+      keyspace = "metric_offset",
+      property = CassandraDataHandlerProperty()
+    )
+
+    every { cassandraFactory.createCluster(any()) } answers { cluster }
+    every { cluster.connect() } answers { session }
+    every { session.prepare(any() as String) } answers { preparedStatement }
+
+    // when & then
+    assertDoesNotThrow { OffsetBasedDataStoreHandler(cassandraFactory, dataStoreHandlerProperty) }
+  }
+
+  @Test
+  internal fun `should throw exception when rollup is less than or equal to 0`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "OffsetBasedDataStoreHandler",
+      ttl = 60,
+      rollup = 0,
+      tenant = "NONE",
+      bucketSize = 150,
+      columnFamily = "metric",
+      keyspace = "metric_offset",
+      property = CassandraDataHandlerProperty()
+    )
+
+    // when & then
+    assertThrows<Exception> { OffsetBasedDataStoreHandler(cassandraFactory, dataStoreHandlerProperty) }
+  }
+
+  @Test
+  internal fun `should return proper startTime and offset with given rollup and bucketSize`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "OffsetBasedDataStoreHandler",
+      ttl = 60,
+      rollup = 15,
+      tenant = "NONE",
+      bucketSize = 10,
+      columnFamily = "metric",
+      keyspace = "metric_offset",
+      property = CassandraDataHandlerProperty()
+    )
+
+    every { cassandraFactory.createCluster(any()) } answers { cluster }
+    every { cluster.connect() } answers { session }
+    every { session.prepare(any() as String) } answers { preparedStatement }
+
+    // when
+    offsetBasedDataStoreHandler = OffsetBasedDataStoreHandler(
+      cassandraFactory,
+      dataStoreHandlerProperty
+    )
+    val timestamp1 = 35L // -> should return offset = 2 and startTime = 0 because 35 will be considered as 30 and quotient is 2
+    val timestamp2 = 45L // -> should return offset = 3 and startTime = 0 because 45 = 15 * 3
+    val timestamp3 = 180L // -> should return offset = 2 and startTime = 150 because bucketSize is 10
+
+    // then
+    assertEquals(0, offsetBasedDataStoreHandler.getStartTime(timestamp1))
+    assertEquals(2, offsetBasedDataStoreHandler.getOffset(timestamp1))
+
+    assertEquals(0, offsetBasedDataStoreHandler.getStartTime(timestamp2))
+    assertEquals(3, offsetBasedDataStoreHandler.getOffset(timestamp2))
+
+    assertEquals(150, offsetBasedDataStoreHandler.getStartTime(timestamp3))
+    assertEquals(2, offsetBasedDataStoreHandler.getOffset(timestamp3))
+  }
+}

--- a/graphene-writer/src/test/kotlin/com/graphene/writer/store/data/cassandra/handler/SimpleDataStoreHandlerTest.kt
+++ b/graphene-writer/src/test/kotlin/com/graphene/writer/store/data/cassandra/handler/SimpleDataStoreHandlerTest.kt
@@ -1,0 +1,75 @@
+package com.graphene.writer.store.data.cassandra.handler
+
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.PreparedStatement
+import com.datastax.driver.core.Session
+import com.graphene.common.store.data.cassandra.CassandraFactory
+import com.graphene.common.store.data.cassandra.property.CassandraDataHandlerProperty
+import com.graphene.writer.store.DataStoreHandlerProperty
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class SimpleDataStoreHandlerTest {
+  private lateinit var simpleDataStoreHandler: SimpleDataStoreHandler
+  private val cassandraFactory: CassandraFactory = mockk()
+  private val cluster: Cluster = mockk()
+  private val session: Session = mockk()
+  private val preparedStatement: PreparedStatement = mockk()
+
+  @Test
+  internal fun `should query to proper keyspace, table with given rollup = 10`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "SimpleDataStoreHandler",
+      ttl = 60,
+      rollup = 10,
+      tenant = "NONE",
+      bucketSize = 120,
+      columnFamily = "metric",
+      keyspace = "metric",
+      property = CassandraDataHandlerProperty()
+    )
+
+    val query = """
+          UPDATE metric.metric_10s
+          USING TTL ?
+          SET data = ?
+          WHERE tenant = ?
+                AND path = ?
+                AND time = ?;
+    """.trimIndent()
+
+    every { cassandraFactory.createCluster(any()) } answers { cluster }
+    every { cluster.connect() } answers { session }
+    every { session.prepare(any() as String) } answers { preparedStatement }
+
+    // when
+    simpleDataStoreHandler = SimpleDataStoreHandler(
+      cassandraFactory,
+      dataStoreHandlerProperty
+    )
+
+    // then
+    assertEquals(query, simpleDataStoreHandler.query.trimIndent())
+  }
+  @Test
+  internal fun `should throw exception when rollup is less than or equal to 0`() {
+    // given
+    val dataStoreHandlerProperty = DataStoreHandlerProperty(
+      type = "OffsetBasedDataStoreHandler",
+      ttl = 60,
+      rollup = 0,
+      tenant = "NONE",
+      bucketSize = 150,
+      columnFamily = "metric",
+      keyspace = "metric_offset",
+      property = CassandraDataHandlerProperty()
+    )
+
+    // when & then
+    assertThrows<Exception> { SimpleDataStoreHandler(cassandraFactory, dataStoreHandlerProperty) }
+  }
+}

--- a/infra/cassandra/2.x/metric.cql
+++ b/infra/cassandra/2.x/metric.cql
@@ -1,6 +1,6 @@
 CREATE KEYSPACE metric WITH replication = {'class': 'NetworkTopologyStrategy', 'ap-northeast-2': '1'} AND durable_writes = true;
 
-CREATE TABLE metric.metric (
+CREATE TABLE metric.metric_60s (
   tenant text,
   path text,
   time bigint,

--- a/infra/cassandra/2.x/metric_offset.cql
+++ b/infra/cassandra/2.x/metric_offset.cql
@@ -1,4 +1,4 @@
-CREATE KEYSPACE metric WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true;
+CREATE KEYSPACE metric_offset_30000 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true;
 
 'bucketSize * rollup = range of data can be stored. here bucketSize = 30000 and rollup = 60s'
 CREATE TABLE metric_offset_30000.metric_60s (

--- a/infra/cassandra/2.x/metric_offset.cql
+++ b/infra/cassandra/2.x/metric_offset.cql
@@ -1,7 +1,7 @@
 CREATE KEYSPACE metric WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true;
 
-# 1 week bucketSize = 604800, 2 weeks = 1209600, 3 weeks = 1814400
-CREATE TABLE metric_offset.metric_604800 (
+'bucketSize * rollup = range of data can be stored. here bucketSize = 30000 and rollup = 60s'
+CREATE TABLE metric_offset_30000.metric_60s (
   tenant text,
   path text,
   startTime bigint,

--- a/infra/cassandra/3.x/metric.cql
+++ b/infra/cassandra/3.x/metric.cql
@@ -1,6 +1,6 @@
 CREATE KEYSPACE metric WITH replication = {'class': 'NetworkTopologyStrategy', 'ap-northeast-2': '3'} AND durable_writes = true;
 
-CREATE TABLE metric.metric (
+CREATE TABLE metric.metric_60s (
   tenant text,
   path text,
   time bigint,

--- a/infra/cassandra/3.x/metric_offset.cql
+++ b/infra/cassandra/3.x/metric_offset.cql
@@ -1,7 +1,7 @@
-CREATE KEYSPACE metric WITH replication = {'class': 'NetworkTopologyStrategy', 'ap-northeast-2': '3'} AND durable_writes = true;
+CREATE KEYSPACE metric_offset_30000 WITH replication = {'class': 'NetworkTopologyStrategy', 'ap-northeast-2': '3'} AND durable_writes = true;
 
 'bucketSize * rollup = range of data can be stored. here bucketSize = 30000 and rollup = 60s'
-CREATE TABLE metric_offset_30000.60s (
+CREATE TABLE metric_offset_30000.metric_60s (
   tenant text,
   path text,
   startTime bigint,

--- a/infra/cassandra/3.x/metric_offset.cql
+++ b/infra/cassandra/3.x/metric_offset.cql
@@ -1,7 +1,7 @@
 CREATE KEYSPACE metric WITH replication = {'class': 'NetworkTopologyStrategy', 'ap-northeast-2': '3'} AND durable_writes = true;
 
-# 1 week bucketSize = 604800, 2 weeks = 1209600, 3 weeks = 1814400
-CREATE TABLE metric_offset.metric_604800 (
+'bucketSize * rollup = range of data can be stored. here bucketSize = 30000 and rollup = 60s'
+CREATE TABLE metric_offset_30000.60s (
   tenant text,
   path text,
   startTime bigint,


### PR DESCRIPTION
related issue: https://github.com/graphene-monitoring/graphene/issues/61

- Offset based C* keyspace will be named by metric_${bucketSize}, and the table will be named by metric_${rollup}s.
- C* keyspace created by SimpleDataStoreHandler will be named by metric which is the same as before, but table will be named by metric_${rollup}s.
- Removed ASCII check in CarbonServerHandler.kt, which is unnecessary.
- Timestamp normalization done by given rollup is removed from Metric.kt, timestamp normalization will be done in each data store handlers.
- This PR will resolve https://github.com/graphene-monitoring/graphene/issues/47, too