### PR TITLE
feature: faster tags autocomplete

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# 1.9.1
+
+## Feature
+- Improved tag autocomplete request performance. [#68](https://github.com/graphene-monitoring/graphene/pull/68)
+  * Users have to migrate documents in Elasticsearch with script located in scripts/v1.9.1/es-index-migration.py
+
 # 1.9.0
 
 ## Feature

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # 1.9.1
 
 ## Feature
-- Improved tag autocomplete request performance. [#68](https://github.com/graphene-monitoring/graphene/pull/68)
+- Improved tag autocomplete request performance. [#69](https://github.com/graphene-monitoring/graphene/pull/69)
   * Users have to migrate documents in Elasticsearch with script located in scripts/v1.9.1/es-index-migration.py
 
 # 1.9.0

--- a/graphene-docker/graphene-reader/Dockerfile
+++ b/graphene-docker/graphene-reader/Dockerfile
@@ -4,8 +4,8 @@ FROM gradle:5.5.1-jdk8
 #         Program version       #
 #################################
 ENV GRAPHENE_TYPE=graphene-reader
-ENV GRAPHENE_BRANCH=1.9.0
-ENV GRAPHENE_VERSION=1.9.0
+ENV GRAPHENE_BRANCH=1.9.1
+ENV GRAPHENE_VERSION=1.9.1
 ENV CONFD_VERSION=0.16.0
 
 #################################

--- a/graphene-docker/graphene-writer/Dockerfile
+++ b/graphene-docker/graphene-writer/Dockerfile
@@ -4,8 +4,8 @@ FROM gradle:5.5.1-jdk8
 #         Program version       #
 #################################
 ENV GRAPHENE_TYPE=graphene-writer
-ENV GRAPHENE_BRANCH=1.9.0
-ENV GRAPHENE_VERSION=1.9.0
+ENV GRAPHENE_BRANCH=1.9.1
+ENV GRAPHENE_VERSION=1.9.1
 ENV CONFD_VERSION=0.16.0
 
 #################################

--- a/graphene-function/src/main/java/com/graphene/reader/service/tag/TagSearchHandler.java
+++ b/graphene-function/src/main/java/com/graphene/reader/service/tag/TagSearchHandler.java
@@ -3,7 +3,7 @@ package com.graphene.reader.service.tag;
 import java.util.List;
 
 public interface TagSearchHandler {
-  List<String> getTags(String tagPrefix, List<String> tagExpressions, String tag, Long from, Long to);
+  List<String> getTags(String tagInput, List<String> tagExpressions, Long from, Long to);
 
-  List<String> getTagValues(String valuePrefix, List<String> tagExpressions, String tag, Long from, Long to, int limit);
+  List<String> getTagValues(String tagValueInput, List<String> tagExpressions, String tag, Long from, Long to);
 }

--- a/graphene-reader/build.gradle
+++ b/graphene-reader/build.gradle
@@ -25,7 +25,7 @@ sourceSets {
 }
 
 group = 'com.graphene.reader'
-version = '1.9.0'
+version = '1.9.1'
 description = 'graphene-reader'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/GraphiteController.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/GraphiteController.kt
@@ -53,7 +53,6 @@ class GraphiteController(
     return tagSearchHandler.getTags(
       tagsAutoCompleteRequest.tagPrefix,
       tagsAutoCompleteRequest.expr,
-      tagsAutoCompleteRequest.tag,
       tagsAutoCompleteRequest.from * 1_000,
       tagsAutoCompleteRequest.until * 1_000
     )
@@ -68,8 +67,7 @@ class GraphiteController(
       tagsAutoCompleteRequest.expr,
       tagsAutoCompleteRequest.tag,
       tagsAutoCompleteRequest.from * 1_000,
-      tagsAutoCompleteRequest.until * 1_000,
-      tagsAutoCompleteRequest.limit
+      tagsAutoCompleteRequest.until * 1_000
     )
   }
 

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/request/TagsAutoCompleteRequest.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/controller/graphite/request/TagsAutoCompleteRequest.kt
@@ -3,7 +3,6 @@ package com.graphene.reader.controller.graphite.request
 import com.graphene.common.utils.DateTimeUtils
 
 data class TagsAutoCompleteRequest(
-  val limit: Int = 100,
   val pretty: Int = 0,
   val expr: List<String> = emptyList(),
   val tag: String = "",

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/IndexBasedKeySearchHandlerProperty.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/IndexBasedKeySearchHandlerProperty.kt
@@ -19,6 +19,7 @@ class IndexBasedKeySearchHandlerProperty : IndexProperty {
   var scroll: Int = 0
   var timeout: Int = 0
   var maxPaths: Int = 0
+  var maxTagResults: Int = 0
 
   override fun keySelectorProperty(): KeySelectorProperty = keySelectorProperty
 
@@ -45,6 +46,8 @@ class IndexBasedKeySearchHandlerProperty : IndexProperty {
   override fun timeout(): Int = timeout
 
   override fun maxPaths(): Int = maxPaths
+
+  override fun maxTagResults(): Int = maxTagResults
 
   override fun toString(): String {
     return "IndexBasedKeySearchHandler{" +

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/IndexProperty.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/IndexProperty.kt
@@ -22,4 +22,5 @@ interface IndexProperty {
   fun scroll(): Int
   fun timeout(): Int
   fun maxPaths(): Int
+  fun maxTagResults(): Int
 }

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/SimpleKeySearchHandlerProperty.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/SimpleKeySearchHandlerProperty.kt
@@ -19,6 +19,7 @@ class SimpleKeySearchHandlerProperty : IndexProperty {
   var scroll: Int = 0
   var timeout: Int = 0
   var maxPaths: Int = 0
+  var maxTagResults: Int = 0
 
   override fun keySelectorProperty(): KeySelectorProperty = keySelectorProperty
 
@@ -45,6 +46,8 @@ class SimpleKeySearchHandlerProperty : IndexProperty {
   override fun timeout(): Int = timeout
 
   override fun maxPaths(): Int = maxPaths
+
+  override fun maxTagResults(): Int = maxTagResults
 
   override fun toString(): String {
     return "SimpleKeySearchHandler{" +

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/TagBasedKeySearchHandlerProperty.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/key/elasticsearch/property/TagBasedKeySearchHandlerProperty.kt
@@ -19,6 +19,7 @@ class TagBasedKeySearchHandlerProperty : IndexProperty {
   var scroll: Int = 0
   var timeout: Int = 0
   var maxPaths: Int = 0
+  var maxTagResults: Int = 200
 
   override fun keySelectorProperty(): KeySelectorProperty = keySelectorProperty
 
@@ -46,6 +47,8 @@ class TagBasedKeySearchHandlerProperty : IndexProperty {
 
   override fun maxPaths(): Int = maxPaths
 
+  override fun maxTagResults(): Int = maxTagResults
+
   override fun toString(): String {
     return "TagBasedKeySearchHandler{" +
       "keySelectorProperty=$keySelectorProperty" +
@@ -60,6 +63,7 @@ class TagBasedKeySearchHandlerProperty : IndexProperty {
       ", scroll=$scroll" +
       ", timeout=$timeout" +
       ", maxPaths=$maxPaths" +
+      ", maxTagResults=$maxTagResults" +
       "}"
   }
 }

--- a/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/elasticsearch/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizer.kt
+++ b/graphene-reader/src/main/kotlin/com/graphene/reader/store/tag/elasticsearch/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizer.kt
@@ -16,7 +16,7 @@ class ElasticsearchIntegratedTagSearchQueryOptimizer : ElasticsearchTagSearchQue
 
   override fun optimize(tagSearchTarget: TagSearchTarget): QueryBuilder {
     val boolQuery = QueryBuilders.boolQuery()
-    addSearchTargetFilter(boolQuery, tagSearchTarget)
+    addTagSearchTargetFilter(boolQuery, tagSearchTarget)
     addQueriesWithTagExpressions(boolQuery, tagSearchTarget.tagExpressions)
     return boolQuery
   }
@@ -68,11 +68,11 @@ class ElasticsearchIntegratedTagSearchQueryOptimizer : ElasticsearchTagSearchQue
     }
   }
 
-  private fun addSearchTargetFilter(boolQuery: BoolQueryBuilder, tagSearchTarget: TagSearchTarget) {
+  private fun addTagSearchTargetFilter(boolQuery: BoolQueryBuilder, tagSearchTarget: TagSearchTarget) {
     if (StringUtils.isNotBlank(tagSearchTarget.tagKey)) {
       boolQuery.filter(QueryBuilders.existsQuery(tagSearchTarget.tagKey))
       if (StringUtils.isNotBlank(tagSearchTarget.tagValue)) {
-        boolQuery.filter(QueryBuilders.prefixQuery(tagSearchTarget.tagKey, tagSearchTarget.tagValue))
+        boolQuery.filter(QueryBuilders.regexpQuery(tagSearchTarget.tagKey, ".*${tagSearchTarget.tagValue}.*"))
       }
     }
   }

--- a/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
+++ b/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/ElasticsearchTagSearchHandlerTest.kt
@@ -19,7 +19,7 @@ internal class ElasticsearchTagSearchHandlerTest {
     // given
     val response = ElasticsearchClient.Response("", SearchHits.empty(), 0, mutableSetOf("a"))
 
-    every { elasticsearchClient.query(any(), any(), any(), any(), any()) } answers { response }
+    every { elasticsearchClient.query(any(), any(), any(), any()) } answers { response }
     every { elasticsearchClient.searchScroll(any()) } answers { ElasticsearchTestUtils.emptyResponse() }
     every { elasticsearchClient.clearScroll(any()) } answers { Unit }
 
@@ -27,7 +27,7 @@ internal class ElasticsearchTagSearchHandlerTest {
 
     val result = elasticsearchTagSearchHandler
       .getTagValues(
-        "", mutableListOf(), "a", 0, 10, 10
+        "", mutableListOf(), "a", 0, 10
       )
 
     // then
@@ -40,7 +40,7 @@ internal class ElasticsearchTagSearchHandlerTest {
     // given
     val response = ElasticsearchClient.Response("", SearchHits.empty(), 0, mutableSetOf())
 
-    every { elasticsearchClient.query(any(), any(), any(), any(), any()) } answers { response }
+    every { elasticsearchClient.query(any(), any(), any(), any()) } answers { response }
     every { elasticsearchClient.searchScroll(any()) } answers { ElasticsearchTestUtils.emptyResponse() }
     every { elasticsearchClient.clearScroll(any()) } answers { Unit }
 
@@ -48,7 +48,7 @@ internal class ElasticsearchTagSearchHandlerTest {
 
     val result = elasticsearchTagSearchHandler
       .getTagValues(
-        "", mutableListOf(), "a", 0, 10, 10
+        "", mutableListOf(), "a", 0, 10
       )
 
     // then

--- a/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizerTest.kt
+++ b/graphene-reader/src/test/kotlin/com/graphene/reader/store/tag/elasticsearch/optimizer/ElasticsearchIntegratedTagSearchQueryOptimizerTest.kt
@@ -25,9 +25,11 @@ internal class ElasticsearchIntegratedTagSearchQueryOptimizerTest {
             }
           },
           {
-            "prefix" : {
+            "regexp" : {
               "server" : {
-                "value" : "a",
+                "value" : ".*a.*",
+                "flags_value" : 65535,
+                "max_determinized_states" : 10000,
                 "boost" : 1.0
               }
             }

--- a/graphene-writer/build.gradle
+++ b/graphene-writer/build.gradle
@@ -37,6 +37,6 @@ sourceSets {
 }
 
 group = 'com.graphene.writer'
-version = '1.9.0'
+version = '1.9.1'
 description = 'graphene-writer'
 sourceCompatibility = '1.8'

--- a/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/elasticsearch/handler/TagBasedKeyStoreHandler.kt
+++ b/graphene-writer/src/main/kotlin/com/graphene/writer/store/key/elasticsearch/handler/TagBasedKeyStoreHandler.kt
@@ -52,13 +52,16 @@ class TagBasedKeyStoreHandler(
       source.field(tag.key, tag.value)
     }
 
-    source.field("@name", grapheneMetric.metricKey())
+    source.field(TAGS_FIELD, grapheneMetric.tags.keys)
+    source.field(NAME_FIELD, grapheneMetric.metricKey())
 
     return source.endObject()
   }
 
   companion object {
     const val TEMPLATE_NAME = "tag-based-key-path-template"
+    const val TAGS_FIELD = "@tags"
+    const val NAME_FIELD = "@name"
     const val SOURCE = """
       {
         "settings": {

--- a/scripts/v1.9.1/es-index-migration/README.md
+++ b/scripts/v1.9.1/es-index-migration/README.md
@@ -1,0 +1,11 @@
+## Key document migration script for faster tag autocomplete request
+Related issue: https://github.com/graphene-monitoring/graphene/issues/68
+
+Simple python script for migrating documents to restructure indexed metric key for faster tag autocomplete request.
+
+### Requirements
+- Python3
+- Python3 Elasticsearch client
+
+### Usage
+```python3 es-index-migration.py ${ELASTICSEARCH_HOST} ${ELASTICSEARCH_PORT}```

--- a/scripts/v1.9.1/es-index-migration/es-index-migration.py
+++ b/scripts/v1.9.1/es-index-migration/es-index-migration.py
@@ -57,7 +57,7 @@ def migrate_docs(es, docs, bulk_size):
       if tag not in tag_list and not tag.startswith('@'):
         tag_list.append(tag)
     update_doc = {'_op_type': 'update', 'doc': {}, '_index': doc_index, '_id': doc_id, '_type': doc_type}
-    update_doc['doc']['@tag_list'] = tag_list
+    update_doc['doc']['@tags'] = tag_list
     bulk.append(update_doc)
     count = count + 1
   if len(bulk) > 0:

--- a/scripts/v1.9.1/es-index-migration/es-index-migration.py
+++ b/scripts/v1.9.1/es-index-migration/es-index-migration.py
@@ -1,0 +1,95 @@
+import sys
+from getpass import getpass
+try:
+  from elasticsearch import Elasticsearch, helpers
+except ImportError:
+  raise ImportError("Please install python elasticsearch dependency.")
+
+
+def migrate(es, tag_index, fetch_size, bulk_size):
+  print("Migrate documents in index: " + tag_index)
+  resp = es.search(
+    index=tag_index,
+    body={},
+    size=fetch_size,
+    scroll='60s',
+    request_timeout=30
+  )
+  if resp['hits']['total'] == 0:
+    print("SKIP! No documents to migrate.")
+    return
+  print("Migration will be done on total " + str(resp['hits']['total']) + " document(s) ...")
+  print("Fetching all documents from index: " + tag_index)
+  scroll_id = resp['_scroll_id']
+  docs_to_migrate = []
+  docs_to_migrate.extend(resp['hits']['hits'])
+  while len(resp['hits']['hits']):
+    resp = es.scroll(
+      scroll_id=scroll_id,
+      scroll='60s',
+      request_timeout=30
+    )
+    print("Fetched total " + str(len(docs_to_migrate)) + " document(s).")
+    docs_to_migrate.extend(resp['hits']['hits'])
+  migrate_docs(es, docs_to_migrate, bulk_size)
+  print("Finished migration in index: " + tag_index)
+
+
+def migrate_docs(es, docs, bulk_size):
+  if len(docs) == 0:
+    return
+  bulk = []
+  total = len(docs)
+  count = 0
+  for doc in docs:
+    if count > 0 and count % bulk_size == 0:
+      print("Bulk updating ... (" + str(count) + "/" + str(total) + ")")
+      helpers.bulk(es, bulk)
+      bulk = []
+    if '_id' not in doc.keys() or '_type' not in doc.keys() or '_index' not in doc.keys():
+      print("Wrong doc!")
+      continue
+    doc_id = doc['_id']
+    doc_type = doc['_type']
+    doc_index = doc['_index']
+    tag_list = []
+    for tag in doc['_source'].keys():
+      if tag not in tag_list and not tag.startswith('@'):
+        tag_list.append(tag)
+    update_doc = {'_op_type': 'update', 'doc': {}, '_index': doc_index, '_id': doc_id, '_type': doc_type}
+    update_doc['doc']['@tag_list'] = tag_list
+    bulk.append(update_doc)
+    count = count + 1
+  if len(bulk) > 0:
+    print("Bulk updating remaining " + str(len(bulk)) + " document(s) ...")
+    helpers.bulk(es, bulk)
+  print("Finished migration for " + str(count) + " among total " + str(total) + " document(s)!")
+
+
+if len(sys.argv) < 3:
+  raise Exception("Please provide elasticsearch host and port.")
+
+es_host = str(sys.argv[1])
+es_port = int(sys.argv[2])
+es_username = str(input("Please enter the Elasticsearch username(leave empty for no authentication): "))
+if len(es_username.strip()) != 0:
+  es_password = str(getpass("Please enter the Elasticsearch password: "))
+
+if len(es_username.strip()) > 0:
+  es = Elasticsearch(
+    [es_host],
+    port=es_port,
+    http_auth=(es_username, es_password)
+  )
+else:
+  es = Elasticsearch(
+    [es_host],
+    port=es_port
+  )
+bulk_size = 10000
+fetch_size = 10000
+
+tag_indices = list(es.indices.get_alias("tag*").keys())
+for tag_index in tag_indices:
+  migrate(es, tag_index, fetch_size, bulk_size)
+print("Migration Complete!")

--- a/scripts/v1.9.1/es-index-migration/requirements.txt
+++ b/scripts/v1.9.1/es-index-migration/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch


### PR DESCRIPTION
Related issue: https://github.com/graphene-monitoring/graphene/issues/68
## v1.9.1
### Faster tags autocomplete
- Reader does not try to fetch document when using aggregation query by setting the value of size parameter to 0.
- Writer indexes tags of a key in a field named ```@tags```.
- Attached migration script for the new key document structure.
