### PR TITLE
[graphene/issues#78] Cannot get rangeIndexes when period is set to 1d

### DIFF
--- a/graphene-common/src/main/kotlin/com/graphene/common/key/RotationStrategy.kt
+++ b/graphene-common/src/main/kotlin/com/graphene/common/key/RotationStrategy.kt
@@ -110,7 +110,7 @@ class TimeBasedRotationStrategy(
     return indexes
   }
 
-  private fun getDateTime(timestampMillis: Long?): DateTime {
+  private fun getOrCurrentDateTime(timestampMillis: Long? = null) {
     return if (Objects.isNull(timestampMillis)) {
       DateTime(TIME_ZONE)
     } else {

--- a/graphene-common/src/main/kotlin/com/graphene/common/rule/GrapheneRules.kt
+++ b/graphene-common/src/main/kotlin/com/graphene/common/rule/GrapheneRules.kt
@@ -29,6 +29,7 @@ object GrapheneRules {
   object Key {
     const val DEFAULT_TYPE = "path"
     const val ROTATION_NONE = "0"
+    const val ROTATION_1D = "1d"
     const val ROTATION_1W = "1w"
 
     fun extractWeekFrom(weeklyDate: String): Int {


### PR DESCRIPTION
Related issue: https://github.com/graphene-monitoring/graphene/issues/78
- Added logic to retrieve proper indexes when period is 1d
- Fixed TimeZone to UTC to avoid any systematic mistake